### PR TITLE
fix: import SkillSkape in import all

### DIFF
--- a/src/workrb/tasks/ranking/__init__.py
+++ b/src/workrb/tasks/ranking/__init__.py
@@ -13,6 +13,7 @@ from workrb.tasks.ranking.jobnorm import JobBERTJobNormRanking
 from workrb.tasks.ranking.skill2job import ESCOSkill2JobRanking
 from workrb.tasks.ranking.skill_extraction import (
     HouseSkillExtractRanking,
+    SkillSkapeExtractRanking,
     TechSkillExtractRanking,
 )
 from workrb.tasks.ranking.skill_similarity import SkillMatch1kSkillSimilarityRanking


### PR DESCRIPTION
Closes #38

Added SkillSkape to __init__ for import all ranking tasks.
Tests added to check if all registered tasks match the import all.