### PR TITLE
refactor: align task groups to paper (JOBSIM/SKILLSIM → Semantic Similarity + Candidate Ranking)

### DIFF
--- a/src/workrb/tasks/abstract/ranking_base.py
+++ b/src/workrb/tasks/abstract/ranking_base.py
@@ -22,11 +22,11 @@ class RankingTaskGroup(BaseTaskGroup, str, Enum):
 
     JOB_NORMALIZATION = f"{_prefix}job_normalization"
     JOB2SKILL = f"{_prefix}job2skill"
-    JOBSIM = f"{_prefix}jobsim"
+    SEMANTIC_SIMILARITY = f"{_prefix}semantic_similarity"
     SKILL2JOB = f"{_prefix}skill2job"
     SKILL_NORMALIZATION = f"{_prefix}skill_normalization"
     SKILL_EXTRACTION = f"{_prefix}skill_extraction"
-    SKILLSIM = f"{_prefix}skillsim"
+    CANDIDATE_RANKING = f"{_prefix}candidate_ranking"
 
 
 class RankingDataset:

--- a/src/workrb/tasks/ranking/freelancer_project_matching.py
+++ b/src/workrb/tasks/ranking/freelancer_project_matching.py
@@ -83,8 +83,8 @@ class _BaseCandidateRanking(RankingTask, ABC):
 
     @property
     def task_group(self) -> RankingTaskGroup:
-        """Job Title Similarity task group."""
-        return RankingTaskGroup.JOBSIM
+        """Candidate Ranking task group."""
+        return RankingTaskGroup.CANDIDATE_RANKING
 
     @property
     def supported_query_languages(self) -> list[Language]:

--- a/src/workrb/tasks/ranking/job_similarity.py
+++ b/src/workrb/tasks/ranking/job_similarity.py
@@ -71,8 +71,8 @@ class JobTitleSimilarityRanking(RankingTask):
 
     @property
     def task_group(self) -> RankingTaskGroup:
-        """Job Title Similarity task group."""
-        return RankingTaskGroup.JOBSIM
+        """Semantic Similarity task group."""
+        return RankingTaskGroup.SEMANTIC_SIMILARITY
 
     @property
     def supported_query_languages(self) -> list[Language]:

--- a/src/workrb/tasks/ranking/skill_similarity.py
+++ b/src/workrb/tasks/ranking/skill_similarity.py
@@ -30,8 +30,8 @@ class SkillMatch1kSkillSimilarityRanking(RankingTask):
 
     @property
     def task_group(self) -> RankingTaskGroup:
-        """Skill similarity task group."""
-        return RankingTaskGroup.SKILLSIM
+        """Semantic Similarity task group."""
+        return RankingTaskGroup.SEMANTIC_SIMILARITY
 
     @property
     def supported_query_languages(self) -> list[Language]:

--- a/tests/test_evaluate_multiple_models.py
+++ b/tests/test_evaluate_multiple_models.py
@@ -79,7 +79,7 @@ def create_mock_results(model_name: str, task_name: str) -> BenchmarkResults:
         task_results={
             task_name: TaskResults(
                 metadata=TaskResultMetadata(
-                    task_group="skillsim",
+                    task_group="rank_semantic_similarity",
                     task_type="ranking",
                     label_type="single_label",
                     description="Find similar skills using the SkillMatch-1K dataset",
@@ -103,7 +103,7 @@ def create_mock_results(model_name: str, task_name: str) -> BenchmarkResults:
             languages=["en"],
             resumed_from_checkpoint=False,
         ),
-        key_metrics_by_task_group={"skillsim": ["map"]},
+        key_metrics_by_task_group={"rank_semantic_similarity": ["map"]},
     )
 
 


### PR DESCRIPTION

### What

Aligns the codebase task grouping with the paper's 7 task groups. Previously, the code had `JOBSIM` (Job Title Sim + Candidate tasks) and `SKILLSIM` (SkillMatch-1K), which didn't match the paper's "Semantic Similarity" and "Candidate Ranking" groups. The freelancer matching datasets are being updated from `JOBSIM` → `CANDIDATE_RANKING`.

### Changes

**Enum refactoring:**
- `JOBSIM` & `SKILLSIM` → `SEMANTIC_SIMILARITY` (Job Title Similarity + SkillMatch-1K)
-  `JOBSIM` → `CANDIDATE_RANKING` (for Query-Candidate + Project-Candidate matching)

**Files changed:**
- `src/workrb/tasks/abstract/ranking_base.py` — Updated `RankingTaskGroup` enum
- `src/workrb/tasks/ranking/job_similarity.py` — `JOBSIM` → `SEMANTIC_SIMILARITY`
- `src/workrb/tasks/ranking/skill_similarity.py` — `SKILLSIM` → `SEMANTIC_SIMILARITY`
- `src/workrb/tasks/ranking/freelancer_project_matching.py` — `JOBSIM` → `CANDIDATE_RANKING`
- `tests/test_evaluate_multiple_models.py` — Updated hardcoded group name strings
- `README.md` — Reorganized task table by task group, updated aggregation example

### Task group mapping (paper ↔ code)

| Paper | Code Enum |
|-------|-----------|
| Job-to-Skill Matching | `JOB2SKILL` |
| Skill-to-Job Matching | `SKILL2JOB` |
| Job Normalization | `JOB_NORMALIZATION` |
| Skill Normalization | `SKILL_NORMALIZATION` |
| **Semantic Similarity** | **`SEMANTIC_SIMILARITY`** (new) |
| Skill Extraction | `SKILL_EXTRACTION` |
| **Candidate Ranking** | **`CANDIDATE_RANKING`** (new) |
