### PR TITLE
feat: Paper results pipeline and robustness improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Each aggregation provides 95% confidence intervals (replace `mean` with `ci_marg
 | --- | --- |
 | `map` | Mean Average Precision |
 | `mrr` | Mean Reciprocal Rank |
+| `ndcg@k` | Normalized Discounted Cumulative Gain with support for top-k cutoff.|
 | `recall@k` | Recall at k (e.g. `recall@5`, `recall@10`) |
 | `hit@k` | Hit rate at k — binary: is any relevant item in the top-k? |
 | `rp@k` | R-Precision at k — precision relative to total relevant items |

--- a/examples/generate_paper_table.py
+++ b/examples/generate_paper_table.py
@@ -1,0 +1,165 @@
+"""
+Load paper experiment results and generate a LaTeX summary table.
+
+Reads results saved by ``run_paper_results.py`` and prints a LaTeX table
+comparing all models across task groups for a given metric.
+
+Usage:
+    python examples/generate_paper_table.py                    # default metric (map)
+    python examples/generate_paper_table.py --metric mrr       # different metric
+    python examples/generate_paper_table.py --aggregation-level task  # per-task columns
+    python examples/generate_paper_table.py --list             # show discovered results
+    python examples/generate_paper_table.py --output table.tex # write to file
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import workrb
+from workrb.metrics.reporting import format_results_latex
+from workrb.results import BenchmarkResults
+
+# Model folder names produced by run_paper_results.py (model.name values).
+MULTILINGUAL_MODELS = [
+    "BM25-lower",
+    "RandomRanking",
+    "JobBERT-v3",
+    "BiEncoder-Qwen3-Embedding-0.6B",
+]
+
+MONOLINGUAL_MODELS = [
+    "ConTeXT-Skill-Extraction-base",
+    "skillmatch-mpnet-curriculum-retriever",
+    "JobBERT-v2",
+]
+
+# Display-friendly names for models and task groups.
+SHORT_NAMES: dict[str, str] = {
+    # Task groups (also controls column order)
+    "rank_job2skill": "J2S",
+    "rank_skill2job": "S2J",
+    "rank_skill_extraction": "SkExt",
+    "rank_skill_normalization": "SkNorm",
+    "rank_semantic_similarity": "Sim",
+    "rank_job_normalization": "JNorm",
+    "rank_candidate_ranking": "CandR",
+    # Models
+    "BM25-lower": "BM25",
+    "RandomRanking": "Random",
+    "JobBERT-v3": "JobBERT-v3",
+    "BiEncoder-Qwen3-Embedding-0.6B": "Qwen3-0.6B",
+    "ConTeXT-Skill-Extraction-base": "ConTeXTMatch",
+    "skillmatch-mpnet-curriculum-retriever": "CurriculumMatch",
+    "JobBERT-v2": "JobBERT-v2",
+}
+
+logger = logging.getLogger(__name__)
+
+
+def discover_results(results_dir: str) -> list[tuple[str, str, Path]]:
+    """Find all results.json files under results_dir.
+
+    Returns list of (group, model_folder_name, path) tuples.
+    """
+    base = Path(results_dir)
+    found = []
+    for group_dir in ("multilingual", "monolingual_en"):
+        group_path = base / group_dir
+        if not group_path.is_dir():
+            continue
+        for model_dir in sorted(group_path.iterdir()):
+            results_file = model_dir / "results.json"
+            if results_file.is_file():
+                found.append((group_dir, model_dir.name, results_file))
+    return found
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate LaTeX table from paper results.")
+    parser.add_argument("--metric", default="map", help="Target metric (default: map)")
+    parser.add_argument(
+        "--results-dir",
+        default="../results/run_paper_results",
+        help="Root results directory (default: ../results/run_paper_results)",
+    )
+    parser.add_argument("--output", default=None, help="Write LaTeX to file instead of stdout")
+    parser.add_argument(
+        "--aggregation-level",
+        default="task_group",
+        choices=["task_group", "task"],
+        help="Column granularity (default: task_group)",
+    )
+    parser.add_argument("--list", action="store_true", help="List discovered results and exit")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
+
+    # Discover result files
+    found = discover_results(args.results_dir)
+    if not found:
+        print(f"No results found under {args.results_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.list:
+        print(f"Discovered {len(found)} result(s) in {args.results_dir}:\n")
+        for group, model, path in found:
+            print(f"  [{group}] {model}  ->  {path}")
+        return
+
+    # Load results in the expected order: multilingual first, then monolingual
+    ordered_models = MULTILINGUAL_MODELS + MONOLINGUAL_MODELS
+    path_by_model: dict[str, Path] = {model: path for _, model, path in found}
+
+    results_list: list[BenchmarkResults] = []
+    loaded_names: list[str] = []
+
+    for model_name in ordered_models:
+        if model_name not in path_by_model:
+            print(f"Warning: results not found for '{model_name}', skipping.", file=sys.stderr)
+            continue
+        results_list.append(workrb.load_results(str(path_by_model[model_name])))
+        loaded_names.append(model_name)
+
+    # Also load any unexpected models found on disk but not in the predefined lists
+    for _, model_name, path in found:
+        if model_name not in ordered_models:
+            print(f"Note: loading extra model '{model_name}'", file=sys.stderr)
+            results_list.append(workrb.load_results(str(path)))
+            loaded_names.append(model_name)
+
+    if not results_list:
+        print("No results loaded.", file=sys.stderr)
+        sys.exit(1)
+
+    # Build model_groups indices based on multilingual/monolingual split
+    multi_indices = [i for i, n in enumerate(loaded_names) if n in MULTILINGUAL_MODELS]
+    mono_indices = [i for i, n in enumerate(loaded_names) if n in MONOLINGUAL_MODELS]
+    extra_indices = [
+        i
+        for i, n in enumerate(loaded_names)
+        if n not in MULTILINGUAL_MODELS and n not in MONOLINGUAL_MODELS
+    ]
+    model_groups = [g for g in [multi_indices, mono_indices, extra_indices] if g]
+
+    latex = format_results_latex(
+        results_list=results_list,
+        target_metric=args.metric,
+        aggregation_level=args.aggregation_level,
+        caption=f"WorkRB Benchmark Results ({args.metric.upper()})",
+        label=f"tab:workrb_{args.metric}",
+        model_groups=model_groups,
+        short_names=SHORT_NAMES,
+        highlight_best=True,
+    )
+
+    if args.output:
+        Path(args.output).write_text(latex + "\n")
+        print(f"LaTeX table written to {args.output}", file=sys.stderr)
+    else:
+        print(latex)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/generate_paper_table.py
+++ b/examples/generate_paper_table.py
@@ -79,10 +79,14 @@ def discover_results(results_dir: str) -> list[tuple[str, str, Path]]:
 def main():
     parser = argparse.ArgumentParser(description="Generate LaTeX table from paper results.")
     parser.add_argument("--metric", default="map", help="Target metric (default: map)")
+    # Default: resolve relative to the repo root (parent of examples/)
+    _default_results_dir = str(
+        Path(__file__).resolve().parent.parent / ".." / "results" / "run_paper_results"
+    )
     parser.add_argument(
         "--results-dir",
-        default="../results/run_paper_results",
-        help="Root results directory (default: ../results/run_paper_results)",
+        default=_default_results_dir,
+        help=f"Root results directory (default: {_default_results_dir})",
     )
     parser.add_argument("--output", default=None, help="Write LaTeX to file instead of stdout")
     parser.add_argument(

--- a/examples/generate_paper_table.py
+++ b/examples/generate_paper_table.py
@@ -95,6 +95,11 @@ def main():
         choices=["task_group", "task"],
         help="Column granularity (default: task_group)",
     )
+    parser.add_argument(
+        "--show-dataset-counts",
+        action="store_true",
+        help="Show number of datasets per model per column in the table",
+    )
     parser.add_argument("--list", action="store_true", help="List discovered results and exit")
     args = parser.parse_args()
 
@@ -156,6 +161,7 @@ def main():
         model_groups=model_groups,
         short_names=SHORT_NAMES,
         highlight_best=True,
+        show_dataset_counts=args.show_dataset_counts,
     )
 
     if args.output:

--- a/examples/run_paper_results.py
+++ b/examples/run_paper_results.py
@@ -117,6 +117,7 @@ def main():
     monolingual_models = [
         ConTeXTMatchModel(),
         CurriculumMatchModel(),
+        JobBERTModel(model_name="TechWolf/JobBERT-v2"),
     ]
 
     print("Running Group 2 (monolingual EN-only)...")

--- a/examples/run_paper_results.py
+++ b/examples/run_paper_results.py
@@ -1,0 +1,141 @@
+"""
+Run paper experiments: two model groups with different language aggregation.
+
+- Group 1 (Multilingual): BM25, Random, JobBERT-v3, BiEncoder-Qwen
+  → All tasks with all languages, SKIP_LANGUAGE_AGGREGATION
+- Group 2 (EN-only): ConTeXTMatch, CurriculumMatch
+  → All tasks with languages=["en"], MONOLINGUAL_ONLY aggregation
+
+Note: MELSRanking has no EN-query datasets — it will have 0 dataset_ids for Group 2
+and be skipped gracefully.
+
+Usage:
+    python examples/run_paper_results.py                # run all (with confirmation)
+    python examples/run_paper_results.py --list         # print tasks and models
+    python examples/run_paper_results.py -y             # skip confirmation prompt
+"""
+
+import argparse
+
+import workrb
+from workrb.models import (
+    BiEncoderModel,
+    BM25Model,
+    ConTeXTMatchModel,
+    CurriculumMatchModel,
+    JobBERTModel,
+    RandomRankingModel,
+)
+from workrb.registry import TaskRegistry
+from workrb.types import ExecutionMode, LanguageAggregationMode
+
+# All ranking tasks, grouped by language structure for documentation.
+ALL_TASKS = [
+    "ESCOJob2SkillRanking",
+    "ESCOSkill2JobRanking",
+    "HouseSkillExtractRanking",
+    "ESCOSkillNormRanking",
+    "JobTitleSimilarityRanking",
+    "JobBERTJobNormRanking",
+    "MELORanking",
+    "MELSRanking",
+    "ProjectCandidateRanking",
+    "SearchQueryCandidateRanking",
+    "SkillSkapeExtractRanking",
+    "TechSkillExtractRanking",
+    "SkillMatch1kSkillSimilarityRanking",
+]
+
+
+def create_tasks(split: str, languages: list[str] | None = None) -> list:
+    """Create all ranking tasks with the given language setting."""
+    tasks = []
+    for name in ALL_TASKS:
+        tasks.append(TaskRegistry.create(name, split=split, languages=languages))
+    return tasks
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run paper experiments with two model groups.")
+    parser.add_argument("--list", action="store_true", help="Print tasks and models, then exit")
+    parser.add_argument("--split", default="test", choices=["val", "test"], help="Dataset split")
+    parser.add_argument("-y", "--yes", action="store_true", help="Skip the confirmation prompt")
+    args = parser.parse_args()
+
+    if args.list:
+        print(f"Multilingual tasks ({len(ALL_TASKS)}):")
+        for name in ALL_TASKS:
+            print(f"  {name}")
+        print(f"\nTotal: {len(ALL_TASKS)} tasks")
+        print("\nGroup 1 — Multilingual (SKIP_LANGUAGE_AGGREGATION, all languages):")
+        print("  BM25Model, RandomRankingModel, JobBERT-v3, BiEncoder-Qwen3-Embedding-0.6B")
+        print("\nGroup 2 — EN-only (MONOLINGUAL_ONLY, languages=['en']):")
+        print("  ConTeXTMatchModel, CurriculumMatchModel")
+        return
+
+    # Summary
+    print(f"Tasks: {len(ALL_TASKS)} ranking tasks")
+    print(f"Split: {args.split}")
+    print("\nGroup 1 — Multilingual: BM25, Random, JobBERT-v3, BiEncoder-Qwen (all languages)")
+    print("Group 2 — EN-only:      ConTeXTMatch, CurriculumMatch (languages=['en'])")
+    print()
+
+    if not args.yes:
+        answer = input("Continue? [Y/n] ").strip().lower()
+        if answer not in ("", "y"):
+            print("Aborted.")
+            return
+
+    # --- Group 1: Multilingual models (all languages) ---
+    print("Creating tasks (all languages)...")
+    tasks_all_langs = create_tasks(args.split, languages=None)
+
+    print("\nCreating multilingual models...")
+    multilingual_models = [
+        BM25Model(),
+        RandomRankingModel(),
+        JobBERTModel(model_name="TechWolf/JobBERT-v3"),
+        BiEncoderModel(model_name="Qwen/Qwen3-Embedding-0.6B"),
+    ]
+
+    print("Running Group 1 (multilingual)...")
+    results_multilingual = workrb.evaluate_multiple_models(
+        models=multilingual_models,
+        tasks=tasks_all_langs,
+        output_folder_template="../results/run_paper_results/multilingual/{model_name}",
+        description="Paper results - multilingual models",
+        force_restart=False,
+        language_aggregation_mode=LanguageAggregationMode.SKIP_LANGUAGE_AGGREGATION,
+        execution_mode=ExecutionMode.LAZY,
+    )
+
+    # --- Group 2: Monolingual EN-only models ---
+    print("\nCreating tasks (EN only)...")
+    tasks_en_only = create_tasks(args.split, languages=["en"])
+
+    print("Creating monolingual EN-only models...")
+    monolingual_models = [
+        ConTeXTMatchModel(),
+        CurriculumMatchModel(),
+    ]
+
+    print("Running Group 2 (monolingual EN-only)...")
+    results_monolingual = workrb.evaluate_multiple_models(
+        models=monolingual_models,
+        tasks=tasks_en_only,
+        output_folder_template="../results/run_paper_results/monolingual_en/{model_name}",
+        description="Paper results - monolingual EN-only models",
+        force_restart=False,
+        language_aggregation_mode=LanguageAggregationMode.MONOLINGUAL_ONLY,  # No cross-lingual datasets
+        execution_mode=ExecutionMode.LAZY,
+    )
+
+    # --- Print all results ---
+    all_results = {**results_multilingual, **results_monolingual}
+    for model_name, results in all_results.items():
+        print(f"\nResults for {model_name}:")
+        print(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/workrb/data/esco.py
+++ b/src/workrb/data/esco.py
@@ -3,6 +3,7 @@ Enhanced ESCO data manager for the hybrid approach.
 """
 
 import logging
+import re
 import urllib.parse
 import zipfile
 from pathlib import Path
@@ -26,7 +27,9 @@ class ESCO:
     """
 
     BASE_URL = "https://ec.europa.eu/esco/download/"
-    SUPPORTED_ESCO_LANGUAGES: tuple[Language, ...] = (
+
+    # Base languages shared across all ESCO versions (1.0+)
+    _BASE_LANGUAGES: tuple[Language, ...] = (
         Language.BG,  # Bulgarian
         Language.ES,  # Spanish
         Language.CS,  # Czech
@@ -51,11 +54,45 @@ class ESCO:
         Language.SL,  # Slovenian
         Language.FI,  # Finnish
         Language.SV,  # Swedish
-        Language.IS,  # Icelandic
-        Language.NO,  # Norwegian
-        Language.AR,  # Arabic
-        Language.UK,  # Ukrainian
     )
+
+    # Language support per ESCO minor version. Keyed by (major, minor).
+    # Patch versions share language support (e.g. 1.0.5 and 1.0.9 both use 1.0).
+    _MINOR_VERSION_LANGUAGES: dict[tuple[int, int], tuple[Language, ...]] = {
+        (1, 0): _BASE_LANGUAGES,
+        (1, 1): _BASE_LANGUAGES
+        + (
+            Language.IS,  # Icelandic (added in 1.1)
+            Language.NO,  # Norwegian (added in 1.1)
+            Language.AR,  # Arabic (added in 1.1)
+            Language.UK,  # Ukrainian (added in 1.1)
+        ),
+    }
+    _MINOR_VERSION_LANGUAGES[(1, 2)] = _MINOR_VERSION_LANGUAGES[(1, 1)]
+
+    # Union of all languages across all versions (for backwards compatibility)
+    SUPPORTED_ESCO_LANGUAGES: tuple[Language, ...] = _MINOR_VERSION_LANGUAGES[(1, 2)]
+
+    @classmethod
+    def _parse_minor_version(cls, version: str) -> tuple[int, int]:
+        """Extract (major, minor) from a version string like '1.2.0'."""
+
+        assert re.fullmatch(r"\d+\.\d+(\.\d+)?", version), f"Invalid version format: {version!r}"
+        parts = version.split(".")
+        return (int(parts[0]), int(parts[1]))
+
+    @classmethod
+    def get_supported_languages(cls, version: str = "1.2.0") -> tuple[Language, ...]:
+        """Return supported languages for a specific ESCO version.
+
+        Language support is determined by the major.minor version — patch versions
+        (e.g. 1.0.5 vs 1.0.9) share the same language set.
+        """
+        minor = cls._parse_minor_version(version)
+        if minor in cls._MINOR_VERSION_LANGUAGES:
+            return cls._MINOR_VERSION_LANGUAGES[minor]
+        logger.warning("Unknown ESCO version '%s', falling back to latest language set.", version)
+        return cls.SUPPORTED_ESCO_LANGUAGES
 
     def __init__(
         self,
@@ -81,9 +118,10 @@ class ESCO:
         self.auto_download = auto_download
 
         self.language = language
-        assert self.language in self.SUPPORTED_ESCO_LANGUAGES, (
-            f"Language {self.language.value} not supported by ESCO. "
-            f"Supported languages: {[lang.value for lang in self.SUPPORTED_ESCO_LANGUAGES]}"
+        supported = self.get_supported_languages(self.version)
+        assert self.language in supported, (
+            f"Language {self.language.value} not supported by ESCO v{self.version}. "
+            f"Supported languages: {[lang.value for lang in supported]}"
         )
 
         # Set up data paths - use cache directory by default

--- a/src/workrb/data/esco.py
+++ b/src/workrb/data/esco.py
@@ -76,7 +76,6 @@ class ESCO:
     @classmethod
     def _parse_minor_version(cls, version: str) -> tuple[int, int]:
         """Extract (major, minor) from a version string like '1.2.0'."""
-
         assert re.fullmatch(r"\d+\.\d+(\.\d+)?", version), f"Invalid version format: {version!r}"
         parts = version.split(".")
         return (int(parts[0]), int(parts[1]))

--- a/src/workrb/metrics/__init__.py
+++ b/src/workrb/metrics/__init__.py
@@ -4,10 +4,11 @@ Metrics and evaluation utilities for WorkRB.
 
 from .classification import calculate_classification_metrics
 from .ranking import calculate_ranking_metrics
-from .reporting import format_results
+from .reporting import format_results, format_results_latex
 
 __all__ = [
     "calculate_classification_metrics",
     "calculate_ranking_metrics",
     "format_results",
+    "format_results_latex",
 ]

--- a/src/workrb/metrics/classification.py
+++ b/src/workrb/metrics/classification.py
@@ -275,7 +275,7 @@ def _to_2d_numpy(array: torch.Tensor | np.ndarray | list) -> np.ndarray:
     """
     # Convert torch tensor to numpy
     if isinstance(array, torch.Tensor):
-        array = array.cpu().numpy()
+        array = array.cpu().float().numpy()
 
     # Convert to numpy array if it's a list
     if isinstance(array, list):

--- a/src/workrb/metrics/ranking.py
+++ b/src/workrb/metrics/ranking.py
@@ -28,7 +28,7 @@ def calculate_ranking_metrics(
     """
     # Convert to numpy if needed
     if isinstance(prediction_matrix, torch.Tensor):
-        prediction_matrix = prediction_matrix.cpu().numpy()
+        prediction_matrix = prediction_matrix.cpu().float().numpy()
 
     # Sort indices by prediction scores (descending)
     sorted_indices = np.argsort(-prediction_matrix, axis=1)

--- a/src/workrb/metrics/ranking.py
+++ b/src/workrb/metrics/ranking.py
@@ -67,6 +67,14 @@ def calculate_ranking_metrics(
             assert k is not None, "k must be provided for hit@k metrics"
             results[metric] = _calculate_hit_at_k(sorted_indices, pos_label_idxs, k)
 
+        elif base_metric == "ndcg":
+            if k is not None:
+                results[metric] = _calculate_ndcg(sorted_indices, pos_label_idxs, k)
+            else:
+                results[metric] = _calculate_ndcg(
+                    sorted_indices, pos_label_idxs, sorted_indices.shape[1]
+                )
+
         else:
             raise ValueError(f"Unknown ranking metric '{metric}'")
 
@@ -194,3 +202,28 @@ def _calculate_rp_at_k(
         rp_scores.append(rp)
 
     return float(np.mean(rp_scores)) if rp_scores else 0.0
+
+
+def _calculate_ndcg(sorted_indices: np.ndarray, pos_label_idxs: list[list[int]], k: int) -> float:
+    """Calculate Normalized Discounted Cumulative Gain@K (binary relevance)."""
+    ndcg_scores = []
+
+    for i, pos_labels in enumerate(pos_label_idxs):
+        if len(pos_labels) == 0:
+            continue
+
+        pos_labels_set = set(pos_labels)
+
+        # DCG@k: sum of 1/log2(rank+1) for relevant items in top-k
+        dcg = 0.0
+        for rank_idx in range(min(k, len(sorted_indices[i]))):
+            if sorted_indices[i][rank_idx] in pos_labels_set:
+                dcg += 1.0 / np.log2(rank_idx + 2)  # 0-based -> log2(pos+1)
+
+        # IDCG@k: ideal DCG with all relevant items ranked first
+        idcg = sum(1.0 / np.log2(j + 2) for j in range(min(k, len(pos_labels))))
+
+        if idcg > 0:
+            ndcg_scores.append(dcg / idcg)
+
+    return float(np.mean(ndcg_scores)) if ndcg_scores else 0.0

--- a/src/workrb/metrics/reporting.py
+++ b/src/workrb/metrics/reporting.py
@@ -2,9 +2,14 @@
 Simple results display system using BenchmarkResults aggregation methods.
 """
 
+from __future__ import annotations
+
 import logging
 from collections import defaultdict
+from collections.abc import Sequence
 from typing import Literal
+
+import pandas as pd
 
 from workrb.results import BenchmarkResults
 from workrb.types import LanguageAggregationMode
@@ -189,3 +194,217 @@ def _display_row(
 
     metrics_display = ",\t".join(metric_strs)
     return f"{row_label:<30} {metrics_display}"
+
+
+# ---------------------------------------------------------------------------
+# LaTeX table formatting
+# ---------------------------------------------------------------------------
+
+
+def format_results_latex(
+    results_list: Sequence[BenchmarkResults],
+    target_metric: str = "map",
+    aggregation_level: Literal["task_group", "task"] = "task_group",
+    value_format: str = "{value:.1f}",
+    scale_factor: float = 100.0,
+    caption: str = "Benchmark Results",
+    label: str = "tab:benchmark_results",
+    model_groups: list[list[int]] | None = None,
+    short_names: dict[str, str] | None = None,
+    highlight_best: bool = True,
+    resize: str | None = r"\columnwidth",
+) -> str:
+    r"""Build a LaTeX table comparing multiple model results.
+
+    Parameters
+    ----------
+    results_list:
+        One :class:`BenchmarkResults` per model, each with its own stored
+        ``language_aggregation_mode``.
+    target_metric:
+        Metric name to extract (e.g. ``"map"``, ``"mrr"``).
+    aggregation_level:
+        Column granularity — ``"task_group"`` or ``"task"``.
+    value_format:
+        Python format string applied to each cell value.  Use ``{value}``
+        as the placeholder (e.g. ``"{value:.1f}"``).
+    scale_factor:
+        Multiply raw metric values by this factor before formatting
+        (default ``100.0`` gives percentage-style numbers).
+    caption:
+        LaTeX ``\caption`` text.
+    label:
+        LaTeX ``\label`` text.
+    model_groups:
+        Optional grouping of model indices for ``\midrule`` separation.
+        E.g. ``[[0, 1, 2], [3, 4]]`` draws a ``\midrule`` between index 2
+        and 3.  When *None*, all models are in a single group.
+    short_names:
+        Rename dictionary applied to both model names and column headers.
+        Keys in insertion order also determine column ordering when the key
+        matches a column name.
+    highlight_best:
+        Bold the highest value in each column.
+    resize:
+        Width argument for ``\resizebox``.  When set (default
+        ``r"\columnwidth"``), the tabular is wrapped in
+        ``\resizebox{<value>}{!}{…}``.  Pass *None* to disable resizing.
+
+    Returns
+    -------
+    str
+        Complete LaTeX ``table`` environment string.
+    """
+    short_names = short_names or {}
+    tag_level = "mean_per_task_group" if aggregation_level == "task_group" else "mean_per_task"
+
+    # ---- collect per-model data ------------------------------------------
+    rows: dict[str, dict[str, float]] = {}  # model_name -> {col_name: value}
+    missing_warnings: list[str] = []
+
+    for results in results_list:
+        mode = LanguageAggregationMode(results.metadata.language_aggregation_mode)
+        all_metrics = results._get_summary_metrics(
+            aggregations=("mean",),
+            language_aggregation_mode=mode,
+        )
+
+        model_name = results.metadata.model_name
+        row: dict[str, float] = {}
+
+        for tag, value in all_metrics.items():
+            if tag.aggregation != "mean":
+                continue
+            if tag.metric_name != target_metric:
+                continue
+
+            if tag.name == tag_level and tag.grouping_name is not None:
+                row[tag.grouping_name] = value
+            elif tag.name == "mean_benchmark":
+                row["Overall"] = value
+
+        rows[model_name] = row
+
+    # ---- build DataFrame -------------------------------------------------
+    df = pd.DataFrame.from_dict(rows, orient="index")
+    df.index.name = "Model"
+
+    # Warn about completely missing columns (metric not present for any model)
+    all_columns = set(df.columns) - {"Overall"}
+    missing_cols = [c for c in sorted(all_columns) if df[c].isna().all()]
+    if missing_cols:
+        msg = (
+            f"Metric '{target_metric}' not found for "
+            f"{'task groups' if aggregation_level == 'task_group' else 'tasks'}: "
+            f"{', '.join(missing_cols)}. These columns will show '--'."
+        )
+        logger.warning(msg)
+        missing_warnings.append(msg)
+
+    # Warn about partially missing cells
+    for model_name in df.index:
+        missing_for_model = [
+            c for c in df.columns if c != "Overall" and pd.isna(df.loc[model_name, c])
+        ]
+        if missing_for_model:
+            msg = (
+                f"Metric '{target_metric}' missing for model '{model_name}' in: "
+                f"{', '.join(missing_for_model)}."
+            )
+            logger.warning(msg)
+            missing_warnings.append(msg)
+
+    # ---- column ordering -------------------------------------------------
+    # Use short_names insertion order for columns that match, then alphabetical remainder
+    ordered_cols: list[str] = []
+    remaining = set(df.columns) - {"Overall"}
+    for key in short_names:
+        # key could be the original name or the short name target
+        if key in remaining:
+            ordered_cols.append(key)
+            remaining.discard(key)
+    for col in sorted(remaining):
+        ordered_cols.append(col)
+    ordered_cols.append("Overall")
+    df = df[[c for c in ordered_cols if c in df.columns]]
+
+    # ---- apply scale factor ----------------------------------------------
+    df = df * scale_factor
+
+    # ---- apply short_names -----------------------------------------------
+    df = df.rename(columns=short_names, index=short_names)
+
+    # ---- find best per column for highlighting ---------------------------
+    best_per_col: dict[str, float] = {}
+    if highlight_best:
+        for col in df.columns:
+            numeric_vals = pd.to_numeric(df[col], errors="coerce")
+            if numeric_vals.notna().any():
+                best_per_col[col] = numeric_vals.max()
+
+    # ---- format cells ----------------------------------------------------
+    def _fmt_cell(val: float, col: str) -> str:
+        if pd.isna(val):
+            return "--"
+        formatted = value_format.format(value=val)
+        if highlight_best and col in best_per_col and val == best_per_col[col]:
+            return f"\\textbf{{{formatted}}}"
+        return formatted
+
+    formatted_df = pd.DataFrame(index=df.index, columns=df.columns)
+    for col in df.columns:
+        formatted_df[col] = [_fmt_cell(v, col) for v in df[col]]
+
+    # ---- build LaTeX string ----------------------------------------------
+    n_cols = len(formatted_df.columns)
+    col_spec = "l" + "c" * (n_cols - 1) + "|c"  # last col (Overall) separated
+
+    lines = [
+        r"\begin{table}[t]",
+        r"\centering",
+        rf"\caption{{{caption}}}",
+        rf"\label{{{label}}}",
+    ]
+    if resize:
+        lines.append(rf"\resizebox{{{resize}}}{{!}}{{%")
+    lines.extend(
+        [
+            rf"\begin{{tabular}}{{{col_spec}}}",
+            r"\toprule",
+        ]
+    )
+
+    # Header row
+    header = "Model & " + " & ".join(formatted_df.columns) + r" \\"
+    lines.append(header)
+    lines.append(r"\midrule")
+
+    # Determine group boundaries
+    if model_groups is None:
+        model_groups = [list(range(len(formatted_df)))]
+
+    row_idx = 0
+    for group_i, group in enumerate(model_groups):
+        for i in group:
+            model = formatted_df.index[i]
+            cells = " & ".join(formatted_df.iloc[i])
+            lines.append(f"{model} & {cells}" + r" \\")
+            row_idx += 1
+        # Add midrule between groups (not after the last)
+        if group_i < len(model_groups) - 1:
+            lines.append(r"\midrule")
+
+    lines.append(r"\bottomrule")
+    lines.append(r"\end{tabular}")
+    if resize:
+        lines.append("}")
+    lines.append(r"\end{table}")
+
+    latex_str = "\n".join(lines)
+
+    # Print warnings summary if any
+    if missing_warnings:
+        warning_block = "\n".join(f"% WARNING: {w}" for w in missing_warnings)
+        latex_str = warning_block + "\n" + latex_str
+
+    return latex_str

--- a/src/workrb/metrics/reporting.py
+++ b/src/workrb/metrics/reporting.py
@@ -414,7 +414,7 @@ def format_results_latex(
     if show_dataset_counts:
         # Map original model names to their df index order
         original_names = list(rows.keys())  # preserves insertion order
-        for group in (model_groups if model_groups is not None else [list(range(len(formatted_df)))]):
+        for group in model_groups if model_groups is not None else [list(range(len(formatted_df)))]:
             # Collect count dicts for models in this group
             group_counts: list[dict[str, int]] = []
             group_model_names: list[str] = []

--- a/src/workrb/metrics/reporting.py
+++ b/src/workrb/metrics/reporting.py
@@ -213,6 +213,7 @@ def format_results_latex(
     short_names: dict[str, str] | None = None,
     highlight_best: bool = True,
     resize: str | None = r"\columnwidth",
+    show_dataset_counts: bool = False,
 ) -> str:
     r"""Build a LaTeX table comparing multiple model results.
 
@@ -249,6 +250,11 @@ def format_results_latex(
         Width argument for ``\resizebox``.  When set (default
         ``r"\columnwidth"``), the tabular is wrapped in
         ``\resizebox{<value>}{!}{…}``.  Pass *None* to disable resizing.
+    show_dataset_counts:
+        When *True*, append a ``#D`` row after each model group showing
+        the number of datasets that contributed to each column's score.
+        If all models in a group share the same counts, a single row is
+        shown; otherwise one row per model is emitted.
 
     Returns
     -------
@@ -284,6 +290,17 @@ def format_results_latex(
                 row["Overall"] = value
 
         rows[model_name] = row
+
+    # ---- collect dataset counts per model --------------------------------
+    dataset_counts: dict[str, dict[str, int]] = {}  # model_name -> {col: count}
+    if show_dataset_counts:
+        for results in results_list:
+            mode = LanguageAggregationMode(results.metadata.language_aggregation_mode)
+            counts = results.get_dataset_counts(
+                aggregation_level=aggregation_level,
+                language_aggregation_mode=mode,
+            )
+            dataset_counts[results.metadata.model_name] = counts
 
     # ---- build DataFrame -------------------------------------------------
     df = pd.DataFrame.from_dict(rows, orient="index")
@@ -390,6 +407,54 @@ def format_results_latex(
     if model_groups is None:
         model_groups = [list(range(len(formatted_df)))]
 
+    # ---- prepare dataset count rows per group (if requested) ---------------
+    # For each group, check if all models share the same counts; if so emit
+    # one shared row, otherwise emit one row per model.
+    group_count_rows: list[list[str]] = []  # parallel to model_groups
+    if show_dataset_counts:
+        # Map original model names to their df index order
+        original_names = list(rows.keys())  # preserves insertion order
+        for group in (model_groups if model_groups is not None else [list(range(len(formatted_df)))]):
+            # Collect count dicts for models in this group
+            group_counts: list[dict[str, int]] = []
+            group_model_names: list[str] = []
+            for i in group:
+                orig_name = original_names[i]
+                group_model_names.append(orig_name)
+                group_counts.append(dataset_counts.get(orig_name, {}))
+
+            # Check if all models in group have identical counts
+            all_same = len(set(tuple(sorted(c.items())) for c in group_counts)) <= 1
+
+            count_lines: list[str] = []
+            if all_same and group_counts:
+                # Single shared row
+                cells = []
+                for col in formatted_df.columns:
+                    # Reverse-lookup original column name from short_names
+                    orig_col = col
+                    for k, v in short_names.items():
+                        if v == col:
+                            orig_col = k
+                            break
+                    cells.append(str(group_counts[0].get(orig_col, "--")))
+                count_lines.append(r"\textit{\#D} & " + " & ".join(cells) + r" \\")
+            else:
+                for model_name, counts in zip(group_model_names, group_counts):
+                    display_name = short_names.get(model_name, model_name)
+                    cells = []
+                    for col in formatted_df.columns:
+                        orig_col = col
+                        for k, v in short_names.items():
+                            if v == col:
+                                orig_col = k
+                                break
+                        cells.append(str(counts.get(orig_col, "--")))
+                    count_lines.append(
+                        rf"\textit{{{display_name} \#D}} & " + " & ".join(cells) + r" \\"
+                    )
+            group_count_rows.append(count_lines)
+
     row_idx = 0
     for group_i, group in enumerate(model_groups):
         for i in group:
@@ -397,6 +462,10 @@ def format_results_latex(
             cells = " & ".join(formatted_df.iloc[i])
             lines.append(f"{model} & {cells}" + r" \\")
             row_idx += 1
+        # Add dataset count rows for this group
+        if show_dataset_counts and group_count_rows:
+            for count_line in group_count_rows[group_i]:
+                lines.append(count_line)
         # Add midrule between groups (not after the last)
         if group_i < len(model_groups) - 1:
             lines.append(r"\midrule")

--- a/src/workrb/metrics/reporting.py
+++ b/src/workrb/metrics/reporting.py
@@ -334,26 +334,33 @@ def format_results_latex(
     # ---- apply short_names -----------------------------------------------
     df = df.rename(columns=short_names, index=short_names)
 
-    # ---- find best per column for highlighting ---------------------------
-    best_per_col: dict[str, float] = {}
+    # ---- find best per column per group for highlighting -------------------
+    # Build a set of best (row_index, col) pairs to bold
+    best_cells: set[tuple[int, str]] = set()
     if highlight_best:
-        for col in df.columns:
-            numeric_vals = pd.to_numeric(df[col], errors="coerce")
-            if numeric_vals.notna().any():
-                best_per_col[col] = numeric_vals.max()
+        resolved_groups = model_groups if model_groups is not None else [list(range(len(df)))]
+        for group in resolved_groups:
+            group_df = df.iloc[group]
+            for col in group_df.columns:
+                numeric_vals = pd.to_numeric(group_df[col], errors="coerce")
+                if numeric_vals.notna().any():
+                    best_val = numeric_vals.max()
+                    for idx in group:
+                        if df.iloc[idx][col] == best_val:
+                            best_cells.add((idx, col))
 
     # ---- format cells ----------------------------------------------------
-    def _fmt_cell(val: float, col: str) -> str:
+    def _fmt_cell(val: float, row_idx: int, col: str) -> str:
         if pd.isna(val):
             return "--"
         formatted = value_format.format(value=val)
-        if highlight_best and col in best_per_col and val == best_per_col[col]:
+        if highlight_best and (row_idx, col) in best_cells:
             return f"\\textbf{{{formatted}}}"
         return formatted
 
     formatted_df = pd.DataFrame(index=df.index, columns=df.columns)
     for col in df.columns:
-        formatted_df[col] = [_fmt_cell(v, col) for v in df[col]]
+        formatted_df[col] = [_fmt_cell(v, i, col) for i, v in enumerate(df[col])]
 
     # ---- build LaTeX string ----------------------------------------------
     n_cols = len(formatted_df.columns)

--- a/src/workrb/models/bi_encoder.py
+++ b/src/workrb/models/bi_encoder.py
@@ -280,7 +280,31 @@ class JobBERTModel(ModelInterface):
 
 @register_model()
 class ConTeXTMatchModel(ModelInterface):
-    """BiEncoder model using sentence-transformers."""
+    """Token-level attention bi-encoder for skill extraction using ConTeXT-Match.
+
+    Unlike standard bi-encoders that produce a single embedding per text, ConTeXT-Match
+    retains per-token embeddings for query texts (shape: (B, L, D)) and computes
+    attention-weighted similarity against mean-pooled target embeddings (shape: (B, D)).
+    This allows the model to focus on the most relevant tokens in a query when matching
+    against each target.
+
+    Memory considerations:
+        The scoring step produces intermediate tensors of shape (num_queries, num_targets, seq_len),
+        which can cause OOM with large query sets. To mitigate this, scoring is batched over queries
+        using ``scoring_batch_size`` — targets are encoded once and reused across all query chunks.
+
+    Batch sizes:
+        This model has two distinct batch size controls:
+
+        - ``scoring_batch_size`` (constructor param, default=32): Controls how many queries are
+          scored against all targets at once in ``_compute_rankings``. Lower values reduce peak
+          GPU memory during the attention-weighted similarity computation. Must be >= 1.
+
+        - ``encode_batch_size`` (param in ``encode()``, default=128): Controls how many texts are
+          tokenized and encoded through the transformer at once. This affects memory during the
+          forward pass of the underlying SentenceTransformer model. Typically less of a bottleneck
+          than the scoring step.
+    """
 
     _NEAR_ZERO_THRESHOLD = 1e-9
 
@@ -288,11 +312,25 @@ class ConTeXTMatchModel(ModelInterface):
         self,
         model_name: str = "TechWolf/ConTeXT-Skill-Extraction-base",
         temperature: float = 1.0,
+        scoring_batch_size: int = 32,
         **kwargs,
     ):
+        """Initialize the ConTeXT-Match model.
+
+        Args:
+            model_name: HuggingFace model identifier for the ConTeXT-Match model.
+            temperature: Temperature for the attention softmax in scoring. Higher values
+                produce softer attention weights across tokens; lower values concentrate
+                attention on the most relevant tokens.
+            scoring_batch_size: Number of queries to score against all targets at once.
+                Controls peak GPU memory during ``_compute_rankings``. Lower values use
+                less memory but may be slower. Must be >= 1.
+            **kwargs: Additional keyword arguments (unused, for compatibility).
+        """
         self.base_model_name = model_name
         self.model = SentenceTransformer(model_name)
         self.temperature = temperature
+        self.scoring_batch_size = max(1, scoring_batch_size)
         # Move to GPU if available
         device = "cuda" if torch.cuda.is_available() else "cpu"
         self.model.to(device)
@@ -302,7 +340,24 @@ class ConTeXTMatchModel(ModelInterface):
     def _context_match_score(
         token_embeddings: torch.Tensor, target_embeddings: torch.Tensor, temperature: float = 1.0
     ) -> torch.Tensor:
-        """Compute attention-weighted similarity between token embeddings and target embeddings."""
+        """Compute attention-weighted similarity between token and target embeddings.
+
+        For each (query, target) pair, computes dot-product attention weights over the
+        query's tokens, then returns the weighted sum of per-token cosine similarities.
+
+        Args:
+            token_embeddings: Query token embeddings of shape (B1, L, D), where B1 is the
+                number of queries, L is the (padded) sequence length, and D is the embedding
+                dimension. Padding tokens should have near-zero embeddings.
+            target_embeddings: Mean-pooled target embeddings of shape (B2, D).
+            temperature: Softmax temperature for attention weights. Controls how sharply
+                the model attends to specific tokens.
+
+        Returns
+        -------
+            Similarity matrix of shape (B1, B2), where entry (i, j) is the attention-weighted
+            cosine similarity between query i and target j.
+        """
         # token_embeddings: (B1, L, D), target_embeddings: (B2, D)
         dot_scores = (token_embeddings @ target_embeddings.T).transpose(1, 2)  # (B1, B2, L)
         dot_scores[dot_scores.abs() < ConTeXTMatchModel._NEAR_ZERO_THRESHOLD] = float("-inf")
@@ -328,7 +383,18 @@ class ConTeXTMatchModel(ModelInterface):
 
     @staticmethod
     def encode_batch(contextmatch_model, texts, mean: bool = False) -> torch.Tensor:
-        """Encode tokens pof the texts ConTeXT-Skill-Extraction-base model."""
+        """Encode a single batch of texts through the ConTeXT-Match model.
+
+        Args:
+            contextmatch_model: The underlying SentenceTransformer model instance.
+            texts: List of texts to encode in this batch.
+            mean: If False (default), returns per-token embeddings for use as queries.
+                If True, returns mean-pooled sentence embeddings for use as targets.
+
+        Returns
+        -------
+            Tensor of token embeddings (variable-length list) or sentence embeddings.
+        """
         args: dict[str, Any] = {
             "normalize_embeddings": False,
             "convert_to_tensor": True,
@@ -339,13 +405,29 @@ class ConTeXTMatchModel(ModelInterface):
 
     @staticmethod
     def encode(
-        contextmatch_model, texts, batch_size: int = 128, mean: bool = False
+        contextmatch_model, texts, encode_batch_size: int = 128, mean: bool = False
     ) -> torch.Tensor:
-        """Encode using the branch of the ConTeXT-Skill-Extraction-base model."""
+        """Encode texts through the ConTeXT-Match model in batches.
+
+        Processes texts in chunks of ``encode_batch_size`` through the transformer,
+        then pads variable-length token embeddings to a uniform sequence length.
+
+        Args:
+            contextmatch_model: The underlying SentenceTransformer model instance.
+            texts: List of texts to encode.
+            encode_batch_size: Number of texts to pass through the transformer at once.
+                Controls GPU memory usage during the encoding forward pass.
+            mean: If False (default), returns padded per-token embeddings (B, L, D).
+                If True, returns mean-pooled sentence embeddings (B, D).
+
+        Returns
+        -------
+            Tensor of shape (B, L, D) for token embeddings or (B, D) for mean-pooled.
+        """
         # For token embeddings, process in batches and handle variable lengths
         all_token_embeddings = []
-        for i in tqdm(range(0, len(texts), batch_size)):
-            batch = texts[i : i + batch_size]
+        for i in tqdm(range(0, len(texts), encode_batch_size)):
+            batch = texts[i : i + encode_batch_size]
             batch_token_embs = ConTeXTMatchModel.encode_batch(contextmatch_model, batch, mean=mean)
             all_token_embeddings.extend(batch_token_embs)
 
@@ -360,12 +442,35 @@ class ConTeXTMatchModel(ModelInterface):
         query_input_type: ModelInputType,
         target_input_type: ModelInputType,
     ) -> torch.Tensor:
-        """Compute ranking scores using attention-weighted similarity."""
+        """Compute ranking scores using attention-weighted similarity.
+
+        Two-phase approach:
+            1. **Encode**: All queries and targets are encoded through the transformer.
+               Queries produce per-token embeddings (B1, L, D); targets are mean-pooled (B2, D).
+               This phase is batched by ``encode_batch_size`` in ``encode()``.
+            2. **Score**: The similarity between queries and targets is computed via
+               ``_context_match_score``. Because this creates intermediate tensors of shape
+               (chunk_size, num_targets, seq_len), queries are processed in chunks of
+               ``scoring_batch_size`` to keep GPU memory bounded. Targets are encoded once
+               and reused across all query chunks.
+
+        Returns
+        -------
+            Similarity matrix of shape (num_queries, num_targets).
+        """
         query_token_embeddings = ConTeXTMatchModel.encode(self.model, queries)
         target_token_embeddings_mean = ConTeXTMatchModel.encode(self.model, targets, mean=True)
-        return self._context_match_score(
-            query_token_embeddings, target_token_embeddings_mean, temperature=self.temperature
-        )
+
+        # Batch over queries to avoid OOM from the (chunk_size, num_targets, seq_len)
+        # intermediate tensor in _context_match_score
+        chunks = []
+        for i in range(0, len(queries), self.scoring_batch_size):
+            query_chunk = query_token_embeddings[i : i + self.scoring_batch_size]
+            chunk_scores = self._context_match_score(
+                query_chunk, target_token_embeddings_mean, temperature=self.temperature
+            )
+            chunks.append(chunk_scores)
+        return torch.cat(chunks, dim=0)
 
     @torch.no_grad()
     def _compute_classification(

--- a/src/workrb/results.py
+++ b/src/workrb/results.py
@@ -2,7 +2,7 @@ import json
 import logging
 import pprint
 from collections import defaultdict
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -183,6 +183,58 @@ class BenchmarkResults(BaseModel):
             **mean_per_task_type,
             **mean_benchmark,
         }
+
+    def get_dataset_counts(
+        self,
+        aggregation_level: Literal["task_group", "task"] = "task_group",
+        language_aggregation_mode: LanguageAggregationMode | None = None,
+    ) -> dict[str, int]:
+        """Return number of datasets per task group (or task) after language filtering.
+
+        Parameters
+        ----------
+        aggregation_level:
+            ``"task_group"`` sums dataset counts across tasks in each group.
+            ``"task"`` returns counts per individual task.
+        language_aggregation_mode:
+            How to filter datasets by language. When *None*, reads the mode
+            stored in ``self.metadata.language_aggregation_mode``.
+
+        Returns
+        -------
+        dict[str, int]
+            Mapping from group/task name to dataset count, plus an
+            ``"Overall"`` key with the total.
+        """
+        if language_aggregation_mode is None:
+            language_aggregation_mode = LanguageAggregationMode(
+                self.metadata.language_aggregation_mode
+            )
+
+        counts: dict[str, int] = defaultdict(int)
+        total = 0
+
+        for task_name, task_result in self.task_results.items():
+            task_count = 0
+            for dataset_id, metrics_result in task_result.datasetid_results.items():
+                if language_aggregation_mode == LanguageAggregationMode.SKIP_LANGUAGE_AGGREGATION:
+                    task_count += 1
+                else:
+                    lang_key = self._get_language_grouping_key(
+                        metrics_result, language_aggregation_mode
+                    )
+                    if lang_key is not None:
+                        task_count += 1
+
+            if aggregation_level == "task":
+                counts[task_name] = task_count
+            else:
+                group_name = task_result.metadata.task_group
+                counts[group_name] += task_count
+            total += task_count
+
+        counts["Overall"] = total
+        return dict(counts)
 
     def _aggregate_datasetids_per_task(
         self,

--- a/src/workrb/tasks/__init__.py
+++ b/src/workrb/tasks/__init__.py
@@ -4,7 +4,7 @@ Task module with hierarchical structure.
 
 # Core task classes
 from .abstract import ClassificationTask, LabelType, Task
-from .abstract.ranking_base import RankingDataset, RankingTask
+from .abstract.ranking_base import DuplicateStrategy, RankingDataset, RankingTask
 
 # Task implementations
 from .classification.job2skill import ESCOJob2SkillClassification
@@ -33,6 +33,7 @@ __all__ = [
     "RankingTask",
     "ClassificationTask",
     "RankingDataset",
+    "DuplicateStrategy",
     # Classification tasks
     "ESCOJob2SkillClassification",
     # Ranking tasks

--- a/src/workrb/tasks/abstract/base.py
+++ b/src/workrb/tasks/abstract/base.py
@@ -74,6 +74,9 @@ class Task(ABC):
         # Load datasets for the selected dataset identifiers
         self.datasets = self._load_datasets(dataset_ids=self.dataset_ids, split=self.split)
 
+        # Skipped datasets (DatasetConfigNotSupported) are excluded from self.dataset_ids
+        self.dataset_ids = list(self.datasets.keys())
+
     def _parse_languages(
         self, languages: list[str], unsupported_lang_mode: Literal["error", "skip"]
     ) -> list[Language]:

--- a/src/workrb/tasks/abstract/base.py
+++ b/src/workrb/tasks/abstract/base.py
@@ -10,6 +10,19 @@ from workrb.types import DatasetLanguages, DatasetSplit, LabelType, Language
 logger = logging.getLogger(__name__)
 
 
+class DatasetConfigNotSupported(Exception):
+    """
+    Raised when a dataset configuration is not supported.
+
+    Only this exception is gracefully skipped during dataset loading;
+    all other errors fail hard to avoid silent failures.
+
+    For example, in dynamic dataset loading with ESCO, a specific language
+    or version may result in not having the required data, such as skill
+    alternatives for ESCOSkillNormalization, resulting in 0 queries or targets.
+    """
+
+
 class BaseTaskGroup(str, Enum):
     """
     Task group enum.
@@ -122,7 +135,15 @@ class Task(ABC):
         """
         datasets = {}
         for dataset_id in dataset_ids:
-            datasets[dataset_id] = self.load_dataset(dataset_id=dataset_id, split=split)
+            try:
+                datasets[dataset_id] = self.load_dataset(dataset_id=dataset_id, split=split)
+            except DatasetConfigNotSupported as e:
+                logger.warning(
+                    "Skipping unsupported dataset '%s' for task '%s': %s",
+                    dataset_id,
+                    self.name,
+                    e,
+                )
         return datasets
 
     def get_task_config(self) -> dict[str, Any]:

--- a/src/workrb/tasks/abstract/ranking_base.py
+++ b/src/workrb/tasks/abstract/ranking_base.py
@@ -55,8 +55,8 @@ class RankingDataset:
         target_indices: list[list[int]],
         target_space: list[str],
         dataset_id: str,
-        duplicate_query_strategy: DuplicateStrategy = DuplicateStrategy.ALLOW,
-        duplicate_target_strategy: DuplicateStrategy = DuplicateStrategy.RAISE,
+        duplicate_query_strategy: DuplicateStrategy = DuplicateStrategy.RESOLVE,
+        duplicate_target_strategy: DuplicateStrategy = DuplicateStrategy.RESOLVE,
     ):
         """Initialize ranking dataset with validation.
 
@@ -116,8 +116,7 @@ class RankingDataset:
             )
             self.target_space = new_target_space
             self.target_indices = [
-                sorted(set(old_to_new[idx] for idx in idx_list))
-                for idx_list in self.target_indices
+                sorted(set(old_to_new[idx] for idx in idx_list)) for idx_list in self.target_indices
             ]
 
     def _resolve_duplicate_queries(self) -> None:

--- a/src/workrb/tasks/abstract/ranking_base.py
+++ b/src/workrb/tasks/abstract/ranking_base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from abc import abstractmethod
 from collections import Counter
 from enum import Enum
@@ -16,6 +17,8 @@ from workrb.types import ModelInputType
 if TYPE_CHECKING:
     from workrb.models.base import ModelInterface
 
+logger = logging.getLogger(__name__)
+
 
 class RankingTaskGroup(BaseTaskGroup, str, Enum):
     _prefix = "rank_"
@@ -29,6 +32,20 @@ class RankingTaskGroup(BaseTaskGroup, str, Enum):
     CANDIDATE_RANKING = f"{_prefix}candidate_ranking"
 
 
+class DuplicateStrategy(str, Enum):
+    """Strategy for handling duplicate queries or targets in a RankingDataset.
+
+    ALLOW: Silently accept duplicates without any action.
+    RAISE: Raise an error if duplicates are found.
+    RESOLVE: Deterministically deduplicate. For targets, keep first occurrence and remap
+        indices. For queries, merge target_indices via union for identical query texts.
+    """
+
+    ALLOW = "allow"
+    RAISE = "raise"
+    RESOLVE = "resolve"
+
+
 class RankingDataset:
     """Structure for ranking datasets."""
 
@@ -38,8 +55,8 @@ class RankingDataset:
         target_indices: list[list[int]],
         target_space: list[str],
         dataset_id: str,
-        allow_duplicate_queries: bool = True,
-        allow_duplicate_targets: bool = False,
+        duplicate_query_strategy: DuplicateStrategy = DuplicateStrategy.ALLOW,
+        duplicate_target_strategy: DuplicateStrategy = DuplicateStrategy.RAISE,
     ):
         """Initialize ranking dataset with validation.
 
@@ -53,20 +70,91 @@ class RankingDataset:
             List of target vocabulary strings.
         dataset_id : str
             Unique identifier for this dataset.
+        duplicate_query_strategy : DuplicateStrategy
+            How to handle duplicate query texts. ALLOW silently accepts them,
+            RAISE raises on duplicates, RESOLVE merges their target_indices via union.
+        duplicate_target_strategy : DuplicateStrategy
+            How to handle duplicate target texts. ALLOW silently accepts them,
+            RAISE raises on duplicates, RESOLVE keeps first occurrence and remaps indices.
         """
         self.query_texts = self._postprocess_texts(query_texts)
         self.target_indices = self._postprocess_indices(target_indices)
         self.target_space = self._postprocess_texts(target_space)
         self.dataset_id = dataset_id
-        self.validate_dataset(allow_duplicate_queries, allow_duplicate_targets)
 
-    def validate_dataset(
+        # Resolve duplicates (targets first to remap indices, then queries to merge)
+        if duplicate_target_strategy == DuplicateStrategy.RESOLVE:
+            self._resolve_duplicate_targets()
+        if duplicate_query_strategy == DuplicateStrategy.RESOLVE:
+            self._resolve_duplicate_queries()
+
+        self._validate_dataset(duplicate_query_strategy, duplicate_target_strategy)
+
+    def _resolve_duplicate_targets(self) -> None:
+        """Deduplicate target_space, keeping first occurrence and remapping indices."""
+        seen: dict[str, int] = {}
+        old_to_new: dict[int, int] = {}
+        new_target_space: list[str] = []
+        duplicates: list[str] = []
+
+        for old_idx, text in enumerate(self.target_space):
+            if text in seen:
+                old_to_new[old_idx] = seen[text]
+                duplicates.append(text)
+            else:
+                new_idx = len(new_target_space)
+                seen[text] = new_idx
+                old_to_new[old_idx] = new_idx
+                new_target_space.append(text)
+
+        if duplicates:
+            logger.warning(
+                "Resolved %d duplicate targets in dataset '%s': %s",
+                len(duplicates),
+                self.dataset_id,
+                duplicates,
+            )
+            self.target_space = new_target_space
+            self.target_indices = [
+                sorted(set(old_to_new[idx] for idx in idx_list))
+                for idx_list in self.target_indices
+            ]
+
+    def _resolve_duplicate_queries(self) -> None:
+        """Deduplicate query_texts, merging target_indices via union."""
+        seen: dict[str, int] = {}
+        new_queries: list[str] = []
+        new_indices: list[list[int]] = []
+        duplicates: list[str] = []
+
+        for query, idx_list in zip(self.query_texts, self.target_indices):
+            if query in seen:
+                pos = seen[query]
+                merged = set(new_indices[pos]) | set(idx_list)
+                new_indices[pos] = sorted(merged)
+                duplicates.append(query)
+            else:
+                seen[query] = len(new_queries)
+                new_queries.append(query)
+                new_indices.append(sorted(idx_list))
+
+        if duplicates:
+            logger.warning(
+                "Resolved %d duplicate queries (merged target_indices) in dataset '%s': %s",
+                len(duplicates),
+                self.dataset_id,
+                duplicates,
+            )
+            self.query_texts = new_queries
+            self.target_indices = new_indices
+
+    def _validate_dataset(
         self,
-        allow_duplicate_queries: bool = True,
-        allow_duplicate_targets: bool = False,
-    ):
-        """Check the dataset."""
-        if not allow_duplicate_queries:
+        duplicate_query_strategy: DuplicateStrategy,
+        duplicate_target_strategy: DuplicateStrategy,
+    ) -> None:
+        """Validate the dataset after construction and optional deduplication."""
+        if duplicate_query_strategy == DuplicateStrategy.RAISE:
             queries_non_unique = [
                 query_text for query_text, cnt in Counter(self.query_texts).items() if cnt > 1
             ]
@@ -74,7 +162,7 @@ class RankingDataset:
                 f"Query texts must be unique. Query texts appearing multiple times: {queries_non_unique} "
             )
 
-        if not allow_duplicate_targets:
+        if duplicate_target_strategy == DuplicateStrategy.RAISE:
             targets_non_unique = [
                 target_text for target_text, cnt in Counter(self.target_space).items() if cnt > 1
             ]
@@ -93,7 +181,7 @@ class RankingDataset:
     def _postprocess_indices(self, indices: list[list[int]]) -> list[list[int]]:
         """Postprocess indices."""
         # Remove duplicates in target_label
-        indices = [list(set(label_list)) for label_list in indices]
+        indices = [sorted(set(label_list)) for label_list in indices]
         return indices
 
     def _postprocess_texts(self, texts: list[str]) -> list[str]:

--- a/src/workrb/tasks/abstract/ranking_base.py
+++ b/src/workrb/tasks/abstract/ranking_base.py
@@ -325,7 +325,7 @@ class RankingTask(Task):
 
         # Convert to numpy if needed
         if isinstance(prediction_matrix, torch.Tensor):
-            prediction_matrix = prediction_matrix.cpu().numpy()
+            prediction_matrix = prediction_matrix.cpu().float().numpy()
 
         # Calculate metrics
         metric_results = calculate_ranking_metrics(

--- a/src/workrb/tasks/abstract/ranking_base.py
+++ b/src/workrb/tasks/abstract/ranking_base.py
@@ -11,7 +11,13 @@ from typing import TYPE_CHECKING
 import torch
 
 from workrb.metrics.ranking import calculate_ranking_metrics
-from workrb.tasks.abstract.base import BaseTaskGroup, DatasetSplit, Task, TaskType
+from workrb.tasks.abstract.base import (
+    BaseTaskGroup,
+    DatasetConfigNotSupported,
+    DatasetSplit,
+    Task,
+    TaskType,
+)
 from workrb.types import ModelInputType
 
 if TYPE_CHECKING:
@@ -153,6 +159,17 @@ class RankingDataset:
         duplicate_target_strategy: DuplicateStrategy,
     ) -> None:
         """Validate the dataset after construction and optional deduplication."""
+        if len(self.query_texts) == 0:
+            raise DatasetConfigNotSupported(
+                f"Dataset '{self.dataset_id}' has 0 queries. "
+                "This typically means that on dynamic dataset loading, no data is available for this language/configuration. "
+            )
+        if len(self.target_space) == 0:
+            raise DatasetConfigNotSupported(
+                f"Dataset '{self.dataset_id}' has 0 targets. "
+                "This typically means that on dynamic dataset loading, no data is available for this language/configuration. "
+            )
+
         if duplicate_query_strategy == DuplicateStrategy.RAISE:
             queries_non_unique = [
                 query_text for query_text, cnt in Counter(self.query_texts).items() if cnt > 1

--- a/src/workrb/tasks/classification/job2skill.py
+++ b/src/workrb/tasks/classification/job2skill.py
@@ -60,8 +60,8 @@ class ESCOJob2SkillClassification(MultiLabelClassificationTask):
 
     @property
     def supported_target_languages(self) -> list[Language]:
-        """Target skills vocabulary spans all ESCO languages."""
-        return list(ESCO.SUPPORTED_ESCO_LANGUAGES)
+        """Target skills vocabulary for the configured ESCO version."""
+        return list(ESCO.get_supported_languages(self.esco_version))
 
     @property
     def input_type(self) -> ModelInputType:

--- a/src/workrb/tasks/ranking/job2skill.py
+++ b/src/workrb/tasks/ranking/job2skill.py
@@ -43,8 +43,8 @@ class ESCOJob2SkillRanking(RankingTask):
 
     @property
     def supported_target_languages(self) -> list[Language]:
-        """Target skills vocabulary spans all ESCO languages."""
-        return list(ESCO.SUPPORTED_ESCO_LANGUAGES)
+        """Target skills vocabulary for the configured ESCO version."""
+        return list(ESCO.get_supported_languages(self.esco_version))
 
     @property
     def label_type(self) -> LabelType:

--- a/src/workrb/tasks/ranking/jobnorm.py
+++ b/src/workrb/tasks/ranking/jobnorm.py
@@ -43,8 +43,8 @@ class JobBERTJobNormRanking(RankingTask):
 
     @property
     def supported_target_languages(self) -> list[Language]:
-        """Supported target languages are all ESCO languages."""
-        return list(ESCO.SUPPORTED_ESCO_LANGUAGES)
+        """Supported target languages for the configured ESCO version."""
+        return list(ESCO.get_supported_languages(self.esco_version))
 
     @property
     def label_type(self) -> LabelType:

--- a/src/workrb/tasks/ranking/melo.py
+++ b/src/workrb/tasks/ranking/melo.py
@@ -4,7 +4,12 @@ from datasets import load_dataset
 
 from workrb.registry import register_task
 from workrb.tasks.abstract.base import DatasetSplit, LabelType, Language
-from workrb.tasks.abstract.ranking_base import RankingDataset, RankingTask, RankingTaskGroup
+from workrb.tasks.abstract.ranking_base import (
+    DuplicateStrategy,
+    RankingDataset,
+    RankingTask,
+    RankingTaskGroup,
+)
 from workrb.types import DatasetLanguages, ModelInputType
 
 
@@ -276,7 +281,11 @@ class MELORanking(RankingTask):
         corpus = list(ds["corpus"]["text"])
 
         return RankingDataset(
-            queries, relevancy_labels, corpus, dataset_id=dataset_id, allow_duplicate_targets=True
+            queries,
+            relevancy_labels,
+            corpus,
+            dataset_id=dataset_id,
+            duplicate_target_strategy=DuplicateStrategy.RESOLVE,
         )
 
     @property

--- a/src/workrb/tasks/ranking/mels.py
+++ b/src/workrb/tasks/ranking/mels.py
@@ -4,7 +4,12 @@ from datasets import load_dataset
 
 from workrb.registry import register_task
 from workrb.tasks.abstract.base import DatasetSplit, LabelType, Language
-from workrb.tasks.abstract.ranking_base import RankingDataset, RankingTask, RankingTaskGroup
+from workrb.tasks.abstract.ranking_base import (
+    DuplicateStrategy,
+    RankingDataset,
+    RankingTask,
+    RankingTaskGroup,
+)
 from workrb.types import DatasetLanguages, ModelInputType
 
 
@@ -225,7 +230,11 @@ class MELSRanking(RankingTask):
         corpus = list(ds["corpus"]["text"])
 
         return RankingDataset(
-            queries, relevancy_labels, corpus, dataset_id=dataset_id, allow_duplicate_targets=True
+            queries,
+            relevancy_labels,
+            corpus,
+            dataset_id=dataset_id,
+            duplicate_target_strategy=DuplicateStrategy.RESOLVE,
         )
 
     @property

--- a/src/workrb/tasks/ranking/skill2job.py
+++ b/src/workrb/tasks/ranking/skill2job.py
@@ -37,8 +37,8 @@ class ESCOSkill2JobRanking(RankingTask):
 
     @property
     def supported_query_languages(self) -> list[Language]:
-        """Supported query languages are all ESCO languages (val is EN-only)."""
-        return list(ESCO.SUPPORTED_ESCO_LANGUAGES)
+        """Supported query languages for the configured ESCO version (val is EN-only)."""
+        return list(ESCO.get_supported_languages(self.esco_version))
 
     @property
     def supported_target_languages(self) -> list[Language]:

--- a/src/workrb/tasks/ranking/skill_extraction.py
+++ b/src/workrb/tasks/ranking/skill_extraction.py
@@ -50,8 +50,8 @@ class BaseESCOSkillExtractRanking(RankingTask):
 
     @property
     def supported_target_languages(self) -> list[Language]:
-        """Supported target languages are all ESCO languages."""
-        return list(ESCO.SUPPORTED_ESCO_LANGUAGES)
+        """Supported target languages for the configured ESCO version."""
+        return list(ESCO.get_supported_languages(self.esco_version))
 
     @property
     def label_type(self) -> LabelType:

--- a/src/workrb/tasks/ranking/skillnorm.py
+++ b/src/workrb/tasks/ranking/skillnorm.py
@@ -29,6 +29,9 @@ class ESCOSkillNormRanking(RankingTask):
     - rnd_split: Random split based on test/validation fraction ratio (default)
     - class_uniform_split: Takes 1 alternative from each class with multiple alternatives
       for validation, rest for test. Disregards the val/test fraction ratio.
+
+    Note: Some ESCO languages have no skill alternatives (e.g. 'uk' in v1.2.0),
+    resulting in 0 queries. These languages are automatically skipped during loading.
     """
 
     def __init__(

--- a/src/workrb/tasks/ranking/skillnorm.py
+++ b/src/workrb/tasks/ranking/skillnorm.py
@@ -69,13 +69,13 @@ class ESCOSkillNormRanking(RankingTask):
 
     @property
     def supported_query_languages(self) -> list[Language]:
-        """Supported query languages are all ESCO languages."""
-        return list(ESCO.SUPPORTED_ESCO_LANGUAGES)
+        """Supported query languages for the configured ESCO version."""
+        return list(ESCO.get_supported_languages(self.esco_version))
 
     @property
     def supported_target_languages(self) -> list[Language]:
-        """Supported target languages are all ESCO languages."""
-        return list(ESCO.SUPPORTED_ESCO_LANGUAGES)
+        """Supported target languages for the configured ESCO version."""
+        return list(ESCO.get_supported_languages(self.esco_version))
 
     @property
     def split_test_fraction(self) -> float:

--- a/tests/test_duplicate_strategy.py
+++ b/tests/test_duplicate_strategy.py
@@ -1,0 +1,208 @@
+"""Tests for DuplicateStrategy in RankingDataset."""
+
+import pytest
+
+from workrb.tasks.abstract.ranking_base import DuplicateStrategy, RankingDataset
+
+
+class TestDuplicateStrategyRaise:
+    """Test that RAISE strategy raises on duplicates."""
+
+    def test_raise_on_duplicate_targets(self):
+        with pytest.raises(AssertionError, match="Target texts must be unique"):
+            RankingDataset(
+                query_texts=["q1"],
+                target_indices=[[0, 1]],
+                target_space=["a", "b", "a"],
+                dataset_id="test",
+                duplicate_target_strategy=DuplicateStrategy.RAISE,
+            )
+
+    def test_raise_on_duplicate_queries(self):
+        with pytest.raises(AssertionError, match="Query texts must be unique"):
+            RankingDataset(
+                query_texts=["q1", "q1"],
+                target_indices=[[0], [1]],
+                target_space=["a", "b"],
+                dataset_id="test",
+                duplicate_query_strategy=DuplicateStrategy.RAISE,
+            )
+
+    def test_no_raise_without_duplicates(self):
+        ds = RankingDataset(
+            query_texts=["q1", "q2"],
+            target_indices=[[0], [1]],
+            target_space=["a", "b"],
+            dataset_id="test",
+            duplicate_query_strategy=DuplicateStrategy.RAISE,
+            duplicate_target_strategy=DuplicateStrategy.RAISE,
+        )
+        assert ds.query_texts == ["q1", "q2"]
+        assert ds.target_space == ["a", "b"]
+
+
+class TestDuplicateStrategyAllow:
+    """Test that ALLOW strategy silently accepts duplicates."""
+
+    def test_allow_duplicate_targets(self):
+        ds = RankingDataset(
+            query_texts=["q1"],
+            target_indices=[[0, 2]],
+            target_space=["a", "b", "a"],
+            dataset_id="test",
+            duplicate_target_strategy=DuplicateStrategy.ALLOW,
+        )
+        assert ds.target_space == ["a", "b", "a"]
+        assert ds.target_indices == [[0, 2]]
+
+    def test_allow_duplicate_queries(self):
+        ds = RankingDataset(
+            query_texts=["q1", "q1"],
+            target_indices=[[0], [1]],
+            target_space=["a", "b"],
+            dataset_id="test",
+            duplicate_query_strategy=DuplicateStrategy.ALLOW,
+        )
+        assert ds.query_texts == ["q1", "q1"]
+
+
+class TestResolveDuplicateTargets:
+    """Test deterministic deduplication of target_space."""
+
+    def test_keeps_first_occurrence(self):
+        ds = RankingDataset(
+            query_texts=["q1"],
+            target_indices=[[0, 2]],
+            target_space=["a", "b", "a"],
+            dataset_id="test",
+            duplicate_target_strategy=DuplicateStrategy.RESOLVE,
+        )
+        assert ds.target_space == ["a", "b"]
+
+    def test_remaps_indices(self):
+        # target_space: ["x", "y", "x", "z"] -> ["x", "y", "z"]
+        # old indices: 0->0, 1->1, 2->0, 3->2
+        ds = RankingDataset(
+            query_texts=["q1", "q2"],
+            target_indices=[[0, 2, 3], [1, 2]],
+            target_space=["x", "y", "x", "z"],
+            dataset_id="test",
+            duplicate_target_strategy=DuplicateStrategy.RESOLVE,
+        )
+        assert ds.target_space == ["x", "y", "z"]
+        # [0, 2, 3] -> [0, 0, 2] -> deduplicated & sorted: [0, 2]
+        assert ds.target_indices[0] == [0, 2]
+        # [1, 2] -> [1, 0] -> sorted: [0, 1]
+        assert ds.target_indices[1] == [0, 1]
+
+    def test_preserves_order(self):
+        ds = RankingDataset(
+            query_texts=["q1"],
+            target_indices=[[0]],
+            target_space=["c", "a", "b", "a", "c"],
+            dataset_id="test",
+            duplicate_target_strategy=DuplicateStrategy.RESOLVE,
+        )
+        # First occurrences in order: c, a, b
+        assert ds.target_space == ["c", "a", "b"]
+
+    def test_no_change_without_duplicates(self):
+        ds = RankingDataset(
+            query_texts=["q1"],
+            target_indices=[[0, 1, 2]],
+            target_space=["a", "b", "c"],
+            dataset_id="test",
+            duplicate_target_strategy=DuplicateStrategy.RESOLVE,
+        )
+        assert ds.target_space == ["a", "b", "c"]
+        assert ds.target_indices == [[0, 1, 2]]
+
+
+class TestResolveDuplicateQueries:
+    """Test deterministic deduplication of query_texts."""
+
+    def test_merges_target_indices(self):
+        ds = RankingDataset(
+            query_texts=["q1", "q1"],
+            target_indices=[[0], [1]],
+            target_space=["a", "b", "c"],
+            dataset_id="test",
+            duplicate_query_strategy=DuplicateStrategy.RESOLVE,
+        )
+        assert ds.query_texts == ["q1"]
+        assert ds.target_indices == [[0, 1]]
+
+    def test_union_deduplicates_indices(self):
+        ds = RankingDataset(
+            query_texts=["q1", "q1"],
+            target_indices=[[0, 1], [1, 2]],
+            target_space=["a", "b", "c"],
+            dataset_id="test",
+            duplicate_query_strategy=DuplicateStrategy.RESOLVE,
+        )
+        assert ds.query_texts == ["q1"]
+        assert ds.target_indices == [[0, 1, 2]]
+
+    def test_preserves_order_of_first_occurrence(self):
+        ds = RankingDataset(
+            query_texts=["q2", "q1", "q2"],
+            target_indices=[[0], [1], [2]],
+            target_space=["a", "b", "c"],
+            dataset_id="test",
+            duplicate_query_strategy=DuplicateStrategy.RESOLVE,
+        )
+        assert ds.query_texts == ["q2", "q1"]
+        assert ds.target_indices == [[0, 2], [1]]
+
+    def test_no_change_without_duplicates(self):
+        ds = RankingDataset(
+            query_texts=["q1", "q2"],
+            target_indices=[[0], [1]],
+            target_space=["a", "b"],
+            dataset_id="test",
+            duplicate_query_strategy=DuplicateStrategy.RESOLVE,
+        )
+        assert ds.query_texts == ["q1", "q2"]
+        assert ds.target_indices == [[0], [1]]
+
+
+class TestResolveBothDuplicates:
+    """Test combined target + query deduplication."""
+
+    def test_resolve_targets_then_queries(self):
+        # Targets: ["x", "y", "x"] -> ["x", "y"], remap 2->0
+        # Queries: ["q1", "q1"] with indices [[0, 2], [1]] -> after target remap [[0], [1]]
+        #   -> merged: [[0, 1]]
+        ds = RankingDataset(
+            query_texts=["q1", "q1"],
+            target_indices=[[0, 2], [1]],
+            target_space=["x", "y", "x"],
+            dataset_id="test",
+            duplicate_query_strategy=DuplicateStrategy.RESOLVE,
+            duplicate_target_strategy=DuplicateStrategy.RESOLVE,
+        )
+        assert ds.target_space == ["x", "y"]
+        assert ds.query_texts == ["q1"]
+        assert ds.target_indices == [[0, 1]]
+
+
+class TestDefaultBehavior:
+    """Test that defaults match previous behavior (queries=ALLOW, targets=RAISE)."""
+
+    def test_default_allows_duplicate_queries(self):
+        ds = RankingDataset(
+            query_texts=["q1", "q1"],
+            target_indices=[[0], [1]],
+            target_space=["a", "b"],
+            dataset_id="test",
+        )
+        assert ds.query_texts == ["q1", "q1"]
+
+    def test_default_raises_on_duplicate_targets(self):
+        with pytest.raises(AssertionError):
+            RankingDataset(
+                query_texts=["q1"],
+                target_indices=[[0, 1]],
+                target_space=["a", "a"],
+                dataset_id="test",
+            )

--- a/tests/test_duplicate_strategy.py
+++ b/tests/test_duplicate_strategy.py
@@ -187,22 +187,24 @@ class TestResolveBothDuplicates:
 
 
 class TestDefaultBehavior:
-    """Test that defaults match previous behavior (queries=ALLOW, targets=RAISE)."""
+    """Test that defaults resolve both query and target duplicates."""
 
-    def test_default_allows_duplicate_queries(self):
+    def test_default_resolves_duplicate_queries(self):
         ds = RankingDataset(
             query_texts=["q1", "q1"],
             target_indices=[[0], [1]],
             target_space=["a", "b"],
             dataset_id="test",
         )
-        assert ds.query_texts == ["q1", "q1"]
+        assert ds.query_texts == ["q1"]
+        assert ds.target_indices == [[0, 1]]
 
-    def test_default_raises_on_duplicate_targets(self):
-        with pytest.raises(AssertionError):
-            RankingDataset(
-                query_texts=["q1"],
-                target_indices=[[0, 1]],
-                target_space=["a", "a"],
-                dataset_id="test",
-            )
+    def test_default_resolves_duplicate_targets(self):
+        ds = RankingDataset(
+            query_texts=["q1"],
+            target_indices=[[0, 1]],
+            target_space=["a", "a"],
+            dataset_id="test",
+        )
+        assert ds.target_space == ["a"]
+        assert ds.target_indices == [[0]]

--- a/tests/test_models/test_contextmatch_model.py
+++ b/tests/test_models/test_contextmatch_model.py
@@ -113,6 +113,114 @@ class TestConTeXTMatchModelUsage:
         assert torch.isfinite(scores).all()
 
 
+TOY_QUERIES = ["software engineer", "data scientist", "project manager", "devops engineer"]
+TOY_TARGETS = [
+    "Python programming",
+    "machine learning",
+    "statistics",
+    "team leadership",
+    "cloud computing",
+]
+
+
+@pytest.fixture(scope="module")
+def contextmatch_model():
+    """Module-scoped fixture to avoid reloading the model for each test."""
+    return ConTeXTMatchModel()
+
+
+class TestConTeXTMatchModelBatching:
+    """Test that scoring_batch_size correctly batches queries without affecting results."""
+
+    def test_scoring_batch_size_initialization_default(self, contextmatch_model):
+        """Test that default scoring_batch_size is 32."""
+        assert contextmatch_model.scoring_batch_size == 32
+
+    def test_scoring_batch_size_initialization_custom(self):
+        """Test custom scoring_batch_size values, including clamping < 1 to 1."""
+        model = ConTeXTMatchModel(scoring_batch_size=16)
+        assert model.scoring_batch_size == 16
+
+        model_clamped = ConTeXTMatchModel(scoring_batch_size=0)
+        assert model_clamped.scoring_batch_size == 1
+
+        model_negative = ConTeXTMatchModel(scoring_batch_size=-5)
+        assert model_negative.scoring_batch_size == 1
+
+    @pytest.mark.parametrize("scoring_batch_size", [1, 2, 3, 1000])
+    def test_scoring_batch_size_does_not_affect_results(self, scoring_batch_size):
+        """Core correctness: different batch sizes must produce identical similarity matrices."""
+        reference_model = ConTeXTMatchModel(scoring_batch_size=1000)
+        batched_model = ConTeXTMatchModel(scoring_batch_size=scoring_batch_size)
+        # Share the same underlying SentenceTransformer to ensure identical encodings
+        batched_model.model = reference_model.model
+
+        reference_scores = reference_model._compute_rankings(
+            queries=TOY_QUERIES,
+            targets=TOY_TARGETS,
+            query_input_type=ModelInputType.JOB_TITLE,
+            target_input_type=ModelInputType.SKILL_NAME,
+        )
+        batched_scores = batched_model._compute_rankings(
+            queries=TOY_QUERIES,
+            targets=TOY_TARGETS,
+            query_input_type=ModelInputType.JOB_TITLE,
+            target_input_type=ModelInputType.SKILL_NAME,
+        )
+
+        assert torch.allclose(reference_scores, batched_scores, atol=1e-6), (
+            f"Scores differ with scoring_batch_size={scoring_batch_size}: "
+            f"max diff = {(reference_scores - batched_scores).abs().max().item():.2e}"
+        )
+
+    def test_scoring_batch_size_one(self, contextmatch_model):
+        """Edge case: batch size of 1 processes each query individually."""
+        contextmatch_model.scoring_batch_size = 1
+
+        scores = contextmatch_model._compute_rankings(
+            queries=TOY_QUERIES,
+            targets=TOY_TARGETS,
+            query_input_type=ModelInputType.JOB_TITLE,
+            target_input_type=ModelInputType.SKILL_NAME,
+        )
+
+        assert scores.shape == (len(TOY_QUERIES), len(TOY_TARGETS))
+        assert isinstance(scores, torch.Tensor)
+        assert torch.isfinite(scores).all()
+
+        # Restore default
+        contextmatch_model.scoring_batch_size = 32
+
+    def test_scoring_batch_size_larger_than_queries(self, contextmatch_model):
+        """When scoring_batch_size > num_queries, everything runs in a single chunk."""
+        contextmatch_model.scoring_batch_size = 1000
+
+        scores = contextmatch_model._compute_rankings(
+            queries=TOY_QUERIES,
+            targets=TOY_TARGETS,
+            query_input_type=ModelInputType.JOB_TITLE,
+            target_input_type=ModelInputType.SKILL_NAME,
+        )
+
+        assert scores.shape == (len(TOY_QUERIES), len(TOY_TARGETS))
+        assert torch.isfinite(scores).all()
+
+        # Restore default
+        contextmatch_model.scoring_batch_size = 32
+
+    def test_single_query_ranking(self, contextmatch_model):
+        """Edge case: only 1 query should produce shape (1, n_targets)."""
+        scores = contextmatch_model._compute_rankings(
+            queries=["software engineer"],
+            targets=TOY_TARGETS,
+            query_input_type=ModelInputType.JOB_TITLE,
+            target_input_type=ModelInputType.SKILL_NAME,
+        )
+
+        assert scores.shape == (1, len(TOY_TARGETS))
+        assert torch.isfinite(scores).all()
+
+
 @pytest.mark.model_performance
 class TestConTeXTMatchModelTechSkillExtraction:
     """Test ConTeXTMatchModel performance on TECH skill extraction test set."""

--- a/tests/test_ranking_metrics.py
+++ b/tests/test_ranking_metrics.py
@@ -1,0 +1,154 @@
+"""Tests for ranking metrics (workrb.metrics.ranking)."""
+
+import numpy as np
+import pytest
+import torch
+
+from workrb.metrics.ranking import calculate_ranking_metrics
+
+# Shared test fixtures: 2 queries x 5 targets
+# Query 0 sorted order: [0, 2, 4, 3, 1]  (scores: 0.9, 0.1, 0.8, 0.2, 0.5)
+# Query 1 sorted order: [3, 1, 2, 0, 4]  (scores: 0.3, 0.7, 0.5, 0.9, 0.1)
+PREDICTION_MATRIX = np.array(
+    [
+        [0.9, 0.1, 0.8, 0.2, 0.5],
+        [0.3, 0.7, 0.5, 0.9, 0.1],
+    ]
+)
+POS_LABEL_IDXS = [[2, 4], [1, 3]]
+
+
+class TestNDCGAtK:
+    """NDCG@k with hand-computed expected values."""
+
+    def test_ndcg_at_k_hand_computed(self):
+        """
+        Query 0: sorted [0,2,4,3,1], relevant {2,4}
+          top-3: [0,2,4] -> DCG = 0 + 1/log2(3) + 1/log2(4) = 0.63093 + 0.5 = 1.13093
+          IDCG = 1/log2(2) + 1/log2(3) = 1.0 + 0.63093 = 1.63093
+          NDCG@3 = 1.13093 / 1.63093 = 0.69342
+
+        Query 1: sorted [3,1,2,0,4], relevant {1,3}
+          top-3: [3,1,2] -> DCG = 1/log2(2) + 1/log2(3) + 0 = 1.0 + 0.63093 = 1.63093
+          IDCG = 1.0 + 0.63093 = 1.63093
+          NDCG@3 = 1.0
+
+        Mean NDCG@3 = (0.69342 + 1.0) / 2 = 0.84671
+        """
+        results = calculate_ranking_metrics(PREDICTION_MATRIX, POS_LABEL_IDXS, metrics=["ndcg@3"])
+        assert results["ndcg@3"] == pytest.approx(0.84671, abs=1e-4)
+
+    def test_ndcg_at_k_1(self):
+        """
+        Query 0: top-1 is idx 0, not relevant -> NDCG@1 = 0.0
+        Query 1: top-1 is idx 3, relevant -> NDCG@1 = 1.0
+        Mean = 0.5
+        """
+        results = calculate_ranking_metrics(PREDICTION_MATRIX, POS_LABEL_IDXS, metrics=["ndcg@1"])
+        assert results["ndcg@1"] == pytest.approx(0.5, abs=1e-4)
+
+
+class TestNDCGFullList:
+    """NDCG over the full ranked list (no @k)."""
+
+    def test_ndcg_full_list(self):
+        """Full-list NDCG should equal NDCG@5 for a 5-column matrix."""
+        results = calculate_ranking_metrics(PREDICTION_MATRIX, POS_LABEL_IDXS, metrics=["ndcg"])
+        assert results["ndcg"] == pytest.approx(0.84671, abs=1e-4)
+
+    def test_ndcg_full_equals_ndcg_at_n_targets(self):
+        """Ndcg and ndcg@n_targets must be identical."""
+        results = calculate_ranking_metrics(
+            PREDICTION_MATRIX, POS_LABEL_IDXS, metrics=["ndcg", "ndcg@5"]
+        )
+        assert results["ndcg"] == pytest.approx(results["ndcg@5"])
+
+
+class TestNDCGEdgeCases:
+    """Edge cases for NDCG computation."""
+
+    def test_perfect_ranking(self):
+        """When relevant items are ranked first, NDCG = 1.0."""
+        prediction_matrix = np.array([[0.1, 0.9, 0.8]])  # sorted: [1, 2, 0]
+        pos_label_idxs = [[1, 2]]
+        results = calculate_ranking_metrics(prediction_matrix, pos_label_idxs, metrics=["ndcg@3"])
+        assert results["ndcg@3"] == pytest.approx(1.0, abs=1e-4)
+
+    def test_worst_ranking(self):
+        """
+        Relevant items ranked last.
+        prediction_matrix = [[0.9, 0.1, 0.2]]  sorted: [0, 2, 1]
+        relevant: {1, 2}
+        DCG@3 = 0 + 1/log2(3) + 1/log2(4) = 0.63093 + 0.5 = 1.13093
+        IDCG@3 = 1/log2(2) + 1/log2(3) = 1.0 + 0.63093 = 1.63093
+        NDCG = 0.69342
+        """
+        prediction_matrix = np.array([[0.9, 0.1, 0.2]])
+        pos_label_idxs = [[1, 2]]
+        results = calculate_ranking_metrics(prediction_matrix, pos_label_idxs, metrics=["ndcg@3"])
+        assert results["ndcg@3"] == pytest.approx(0.69342, abs=1e-4)
+
+    def test_no_relevant_items(self):
+        """Queries with no positives are skipped; empty result -> 0.0."""
+        prediction_matrix = np.array([[0.5, 0.3, 0.9]])
+        pos_label_idxs = [[]]
+        results = calculate_ranking_metrics(prediction_matrix, pos_label_idxs, metrics=["ndcg@3"])
+        assert results["ndcg@3"] == pytest.approx(0.0, abs=1e-4)
+
+    def test_all_items_relevant(self):
+        """When all items are relevant, any ordering gives NDCG = 1.0."""
+        prediction_matrix = np.array([[0.5, 0.3, 0.9]])
+        pos_label_idxs = [[0, 1, 2]]
+        results = calculate_ranking_metrics(prediction_matrix, pos_label_idxs, metrics=["ndcg@3"])
+        assert results["ndcg@3"] == pytest.approx(1.0, abs=1e-4)
+
+    def test_k_greater_than_n_targets(self):
+        """K > n_targets should work and equal ndcg over the full list."""
+        results_large_k = calculate_ranking_metrics(
+            PREDICTION_MATRIX, POS_LABEL_IDXS, metrics=["ndcg@10"]
+        )
+        results_full = calculate_ranking_metrics(
+            PREDICTION_MATRIX, POS_LABEL_IDXS, metrics=["ndcg@5"]
+        )
+        assert results_large_k["ndcg@10"] == pytest.approx(results_full["ndcg@5"])
+
+    def test_single_query_single_target(self):
+        """1x1 matrix with the single item being relevant -> NDCG = 1.0."""
+        prediction_matrix = np.array([[0.5]])
+        pos_label_idxs = [[0]]
+        results = calculate_ranking_metrics(prediction_matrix, pos_label_idxs, metrics=["ndcg@1"])
+        assert results["ndcg@1"] == pytest.approx(1.0, abs=1e-4)
+
+
+class TestNDCGInputTypes:
+    """Test NDCG with different input types."""
+
+    def test_torch_tensor_input(self):
+        """torch.Tensor input should produce the same result as numpy."""
+        results_np = calculate_ranking_metrics(
+            PREDICTION_MATRIX, POS_LABEL_IDXS, metrics=["ndcg@3"]
+        )
+        results_torch = calculate_ranking_metrics(
+            torch.tensor(PREDICTION_MATRIX), POS_LABEL_IDXS, metrics=["ndcg@3"]
+        )
+        assert results_torch["ndcg@3"] == pytest.approx(results_np["ndcg@3"])
+
+
+class TestRankingMetricsGeneral:
+    """General tests for the ranking metrics module."""
+
+    def test_unknown_metric_raises(self):
+        """Unknown metric names should raise ValueError."""
+        with pytest.raises(ValueError, match="Unknown ranking metric"):
+            calculate_ranking_metrics(PREDICTION_MATRIX, POS_LABEL_IDXS, metrics=["nonexistent"])
+
+    def test_existing_metrics_still_work(self):
+        """Smoke test: all existing metrics return float values without error."""
+        results = calculate_ranking_metrics(
+            PREDICTION_MATRIX,
+            POS_LABEL_IDXS,
+            metrics=["map", "mrr", "recall@3", "hit@3", "rp@3"],
+        )
+        for metric_name in ["map", "mrr", "recall@3", "hit@3", "rp@3"]:
+            assert isinstance(results[metric_name], float)
+            assert 0.0 <= results[metric_name] <= 1.0


### PR DESCRIPTION
### Summary

Adds end-to-end support for reproducing paper benchmark results — from running experiments to generating publication-ready LaTeX tables — while fixing several robustness issues discovered during large-scale multilingual evaluation runs.

### Changes

#### New: Paper results pipeline
- **`examples/run_paper_results.py`** — Script to run the full benchmark suite across multilingual and monolingual model configurations (BM25, JobBERT-v2/v3, Qwen3, ConTeXTMatch, CurriculumMatch).
- **`examples/generate_paper_table.py`** — Script to load saved results and generate a formatted LaTeX comparison table with model grouping, short names, bold-best highlighting, and optional dataset count rows.
- **`src/workrb/metrics/reporting.py`** — New `format_results_latex()` function (~290 lines) that builds a complete LaTeX `table` environment from multiple `BenchmarkResults`, with support for model groups, `\midrule` separators, column renaming/reordering, `\resizebox`, and per-group dataset count rows.
- **`src/workrb/results.py`** — New `BenchmarkResults.get_dataset_counts()` method to report how many datasets contribute to each task group or task score after language filtering.

#### New: Duplicate handling in ranking datasets
- **`DuplicateStrategy` enum** (`ALLOW`, `RAISE`, `RESOLVE`) replaces the old boolean `allow_duplicate_queries` / `allow_duplicate_targets` flags in `RankingDataset`.
- **`RESOLVE` mode** (new default) deterministically deduplicates:
  - *Targets:* keeps first occurrence and remaps all indices.
  - *Queries:* merges `target_indices` via set union for identical query texts.
- All ranking tasks (`melo`, `mels`, `skillnorm`, etc.) updated to use the new API.
- **`tests/test_duplicate_strategy.py`** — 210-line test suite covering `RAISE`, `ALLOW`, and `RESOLVE` strategies for both queries and targets.

#### New: Graceful handling of unsupported dataset configs
- **`DatasetConfigNotSupported` exception** — New exception type in `base.py` for datasets that dynamically produce 0 queries or targets (e.g., an ESCO language/version lacking skill alternatives).
- `Task._load_datasets()` catches `DatasetConfigNotSupported` and logs a warning instead of crashing, then updates `self.dataset_ids` to reflect only successfully loaded datasets.
- `RankingDataset` validation raises `DatasetConfigNotSupported` when query or target count is 0.

#### New: ConTeXTMatch query batching for large ranking tasks
- `ConTeXTMatchModel._compute_rankings()` now scores queries in configurable chunks (`scoring_batch_size`, default 32) to prevent OOM from the `(num_queries, num_targets, seq_len)` intermediate tensor.
- Targets are encoded once and reused across all query chunks.
- Renamed `batch_size` parameter to `encode_batch_size` for clarity.
- **`tests/test_models/test_contextmatch_model.py`** — 108-line test suite for the ConTeXTMatch model including batching behavior.

#### Fix: Version-dependent ESCO language support
- `ESCO.get_supported_languages(version)` returns the correct language set per major.minor version (e.g., Icelandic/Norwegian/Arabic/Ukrainian only available from v1.1+).
- All ranking tasks now call `ESCO.get_supported_languages(self.esco_version)` instead of the static `SUPPORTED_ESCO_LANGUAGES` tuple.

#### Fix: Miscellaneous
- Cast prediction matrices to `.float()` before `.numpy()` to avoid dtype errors with bfloat16 models.
- Use `sorted(set(...))` instead of `list(set(...))` for deterministic index ordering.

### Files changed (22)

| Area | Files |
|------|-------|
| Examples | `examples/run_paper_results.py`, `examples/generate_paper_table.py` |
| Metrics & Reporting | `src/workrb/metrics/reporting.py`, `src/workrb/metrics/__init__.py`, `src/workrb/metrics/classification.py`, `src/workrb/metrics/ranking.py` |
| Models | `src/workrb/models/bi_encoder.py` |
| Results | `src/workrb/results.py` |
| Tasks (core) | `src/workrb/tasks/abstract/base.py`, `src/workrb/tasks/abstract/ranking_base.py`, `src/workrb/tasks/__init__.py` |
| Tasks (ranking) | `job2skill.py`, `skill2job.py`, `skill_extraction.py`, `jobnorm.py`, `skillnorm.py`, `melo.py`, `mels.py` |
| Data | `src/workrb/data/esco.py` |
| Tasks (classification) | `src/workrb/tasks/classification/job2skill.py` |
| Tests | `tests/test_duplicate_strategy.py`, `tests/test_models/test_contextmatch_model.py` |

### Test plan

- [ ] Run `tests/test_duplicate_strategy.py` — validates `RAISE`, `ALLOW`, and `RESOLVE` strategies for both query and target deduplication
- [ ] Run `tests/test_models/test_contextmatch_model.py` — validates ConTeXTMatch encoding and batched scoring
- [ ] Run existing test suite to confirm no regressions in ranking/classification tasks
- [ ] Verify `examples/run_paper_results.py` executes end-to-end with at least one model
- [ ] Verify `examples/generate_paper_table.py` generates valid LaTeX output from saved results

### Breaking changes

- `RankingDataset.__init__` signature changed: `allow_duplicate_queries` / `allow_duplicate_targets` replaced by `duplicate_query_strategy` / `duplicate_target_strategy` (enum-based). Any external callers using the old boolean flags will need to update.
- `ConTeXTMatchModel.encode()` parameter renamed from `batch_size` to `encode_batch_size`.